### PR TITLE
Fixed so that sampling AI calls are also added to the chathistory as …

### DIFF
--- a/Rappen.AI.WinForm/AiCommunication.cs
+++ b/Rappen.AI.WinForm/AiCommunication.cs
@@ -85,7 +85,7 @@ namespace Rappen.AI.WinForm
         /// </summary>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public static string SamplingAI(string systemPrompt, string userPrompt, string supplier, string model, string apikey)
+        public static ChatResponse SamplingAI(string systemPrompt, string userPrompt, string supplier, string model, string apikey)
         {
             using (IChatClient chatClient = GetChatClient(supplier, model, apikey).Build())
             {
@@ -99,7 +99,8 @@ namespace Rappen.AI.WinForm
                     .GetResponseAsync(chatMessages)
                     .GetAwaiter()
                     .GetResult();
-                return response.Text;
+
+                return response;
             }
         }
 

--- a/Rappen.AI.WinForm/ChatMessageHistory.cs
+++ b/Rappen.AI.WinForm/ChatMessageHistory.cs
@@ -125,7 +125,15 @@ namespace Rappen.AI.WinForm
             response.Messages.ToList().ForEach(x => Add(x));
         }
 
+        public void Add(ChatResponse response, bool hidden)
+        {
+            Responses.Add(response);
+            response.Messages.ToList().ForEach(x => Add(x, hidden));
+        }
+
         private void Add(ChatMessage message) => Add(message.Role, message.Text, false);
+
+        private void Add(ChatMessage message, bool hidden) => Add(message.Role, message.Text, hidden);
 
         public bool HasDialog =>
             Messages?.Any(m => m.Role == ChatRole.User) == true &&


### PR DESCRIPTION
…responses, which both makes the AI remembers the calls and also includes these calls in the total token usage stats.